### PR TITLE
Add timestamp to model name, improve deployment method 🚀

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 
 Bugfixes:
 * [#14](https://github.com/robo-ai/roboai-python-cli/issues/14): Remove engine validations since it was coming as None from the core.
+* [#19](https://github.com/robo-ai/roboai-python-cli/issues/19): Fix issue with model name when it's different than model-language.
 
 Features:
 * [#20](https://github.com/robo-ai/roboai-python-cli/issues/20): Add cross-validation option to test command.
 * Test results are now stored in a generated folder with the timestamp in which the tests were run.
 * Intent details spreadsheet now contains a separate tab with intent statistics (precision, recall and f1-score).
+* [#18](https://github.com/robo-ai/roboai-python-cli/issues/18): Add option to select a model when deploying or packaging a bot. If no model is passed the most recent one is picked up.
+* [#17](https://github.com/robo-ai/roboai-python-cli/issues/17): Add timestamp to model name.
+* Add force option to train command.
 
 ## [0.1.3.1] - 2020-11-25
 

--- a/README.md
+++ b/README.md
@@ -210,11 +210,12 @@ If no language codes are passed, then it'll pair all the languages found and che
 You're now in a position to train the bot. To do so you only need to run the **train** command just as you would do in Rasa. 
 
 ```
-robo-bot train [language-codes] [--path <path> --nlu --core --augmentation <value>]
+robo-bot train [language-codes] [--path <path> --nlu --core --augmentation <value> --dev-config <path to config file> --force]
 ```
 
 It will train the bot and store the model in the language sub-directory. If no language codes are passed, 
-all bots will be trained. 
+all bots will be trained.  
+The **augmentation** and **force** options do not work in the case of NLU training.
 
 ##### Interacting with a bot #####
 

--- a/README.md
+++ b/README.md
@@ -353,11 +353,12 @@ When your bot is ready for deployment, you must train it first and remove any ol
 the bot root directory, and then just execute:
 
 ```
-robo-bot deploy [language-code]
+robo-bot deploy [language-code] --model <path to model file>
 ```
 
 It'll package your bot files and upload them to the ROBO.AI platform, starting a new deployment. This step may take
 some time.  
+If you want you can pass the path to the model you want to deploy. If no model path is passed then the most recent one will be picked up.
 **Note:** if no language-code is provided, it's assumed that you're working with the default Rasa structure.
 
 ##### Checking a bot status #####

--- a/robo_bot_cli/commands/deploy.py
+++ b/robo_bot_cli/commands/deploy.py
@@ -11,19 +11,21 @@ from robo_bot_cli.util.robo import (create_package, create_runtime,
                                     validate_robo_session)
 
 
-@click.command(name='deploy',
-               help='Deploy the current bot into the ROBO.AI platform.')
-@click.argument('language', nargs=-1,)
-@click.option('--skip-packaging', is_flag=True, type=bool, default=False,
-              help='Skips the packaging process, assuming the package is already built.')
-@click.option('--package-file', type=str, default=None,
-              help='Path to the package file to be deployed, '
-              'setting this option will skip the packaging process.')
-@click.option('--bot-uuid', type=str, default=None,
-              help='Overrides the bot UUID from the current bot manifest file.')
-@click.option('--runtime-base-version', type=str, default=None,
-              help='Overrides the runtime base version from the current bot manifest file.')
-def command(language: tuple, skip_packaging: bool, package_file: str, bot_uuid: str, runtime_base_version: str):
+@click.command(name="deploy",
+               help="Deploy the current bot into the ROBO.AI platform.")
+@click.argument("language", nargs=-1,)
+@click.option("--skip-packaging", is_flag=True, type=bool, default=False,
+              help="Skips the packaging process, assuming the package is already built.")
+@click.option("--package-file", type=str, default=None,
+              help="Path to the package file to be deployed, "
+              "setting this option will skip the packaging process.")
+@click.option("--bot-uuid", type=str, default=None,
+              help="Overrides the bot UUID from the current bot manifest file.")
+@click.option("--runtime-base-version", type=str, default=None,
+              help="Overrides the runtime base version from the current bot manifest file.")
+@click.option("--model", type=click.Path(), default=None,
+              help="Path to the model to be packaged. If no model is passed then the latest one is picked up.")
+def command(language: tuple, skip_packaging: bool, package_file: str, bot_uuid: str, runtime_base_version: str, model: str):
     """
     Deploy a bot into the ROBO.AI platform.
 
@@ -33,16 +35,18 @@ def command(language: tuple, skip_packaging: bool, package_file: str, bot_uuid: 
         package_file (str): optional flag stating where the package file is stored
         bot_uuid (str): optional argument stating the ID of the bot
         runtime_base_version (str): optional argument stating the runtime version
+        model (str): optional argument with the path to the model to be packaged.
+                    If no model is passed then the latest one is picked up.
     """
     validate_robo_session()
 
     if len(language) == 0:
-        bot_dir = bot_ignore_dir = abspath('.')
+        bot_dir = bot_ignore_dir = abspath(".")
     elif len(language) == 1:
-        bot_dir = abspath(join('.', 'languages', language[0]))
+        bot_dir = abspath(join(".", "languages", language[0]))
         bot_ignore_dir = dirname(dirname(bot_dir))
     else:
-        print_message('Please select only one bot to deploy.')
+        print_message("Please select only one bot to deploy.\n")
         exit(0)
 
     if not bot_uuid:
@@ -51,12 +55,10 @@ def command(language: tuple, skip_packaging: bool, package_file: str, bot_uuid: 
     if not runtime_base_version:
         runtime_base_version = get_current_bot_base_version(bot_dir)
 
-    # validate_bot(bot_uuid)
-
     if package_file:
         validate_package_file(package_file)
     elif not skip_packaging:
-        package_file = create_package(bot_dir, bot_ignore_dir)
+        package_file = create_package(bot_dir, bot_ignore_dir, model)
     elif not package_file:
         package_file = get_default_package_path()
 
@@ -67,7 +69,7 @@ def command(language: tuple, skip_packaging: bool, package_file: str, bot_uuid: 
     else:
         create_runtime(bot_uuid, package_file, runtime_base_version)
 
-    print_success('Deployment complete')
+    print_success("Deployment complete.\n")
 
 
 if __name__ == "__main__":

--- a/robo_bot_cli/commands/interactive.py
+++ b/robo_bot_cli/commands/interactive.py
@@ -1,6 +1,7 @@
 import click
 import os
 from os.path import join, abspath
+import glob
 
 
 @click.command(name='interactive', help='Run in interactive learning mode where you can \
@@ -18,8 +19,9 @@ def command(language: str):
 
 def start_interactive_mode(language: str):
 
-    model_path = join(abspath('.'), 'languages', language,
-                      'models', f'model-{language}.tar.gz')
+    list_of_models = glob.glob(join(abspath("."), "languages", language, "models", "*.tar.gz"))
+    latest_model = max(list_of_models, key=os.path.getctime)
+
     config_path = join(abspath('.'), 'languages', language, 'config.yml')
     domain_path = join(abspath('.'), 'languages', language, 'domain.yml')
     nlu_path = join(abspath('.'), 'languages', language, 'data')
@@ -27,7 +29,7 @@ def start_interactive_mode(language: str):
     endpoints_path = join(abspath('.'), 'endpoints.yml')
     out_path = join(abspath('.'), 'languages', language, 'interactive')
 
-    os.system(f'rasa interactive --model {model_path} --config {config_path} --domain {domain_path} \
+    os.system(f'rasa interactive --model {latest_model} --config {config_path} --domain {domain_path} \
             --data {stories_path} {nlu_path} --endpoints {endpoints_path} --out {out_path}')
 
 

--- a/robo_bot_cli/commands/package.py
+++ b/robo_bot_cli/commands/package.py
@@ -6,10 +6,12 @@ from robo_bot_cli.util.cli import print_success, print_message
 from robo_bot_cli.util.robo import create_package
 
 
-@click.command(name='package',
-               help='Package the required bot and make it ready for deployment.')
-@click.argument('language', nargs=-1,)
-def command(language: tuple):
+@click.command(name="package",
+               help="Package the required bot and make it ready for deployment.")
+@click.argument("language", nargs=-1,)
+@click.option("--model", type=click.Path(), default=None,
+              help="Path to the model to be packaged. If no model is passed then the latest one is picked up.")
+def command(language: tuple, model: str):
     """
 
     Package the required bot and make it ready for deployment.
@@ -18,17 +20,17 @@ def command(language: tuple):
         language (tuple): language code of the bot to create a package of.
     """
     if len(language) == 0:
-        bot_dir = bot_ignore_dir = abspath('.')
+        bot_dir = bot_ignore_dir = abspath(".")
     elif len(language) == 1:
-        bot_dir = abspath(join('.', 'languages', language[0]))
+        bot_dir = abspath(join(".", "languages", language[0]))
         bot_ignore_dir = dirname(dirname(bot_dir))
     else:
-        print_message('Please select only one bot to package.')
+        print_message("Please select only one bot to package.")
         exit(0)
 
-    package_path = create_package(bot_dir, bot_ignore_dir)
+    package_path = create_package(bot_dir, bot_ignore_dir, model)
     print_message("Package file: {0}".format(package_path))
-    print_success("The packaging is complete.")
+    print_success("The packaging is complete.\n")
 
 
 if __name__ == "__main__":

--- a/robo_bot_cli/commands/shell.py
+++ b/robo_bot_cli/commands/shell.py
@@ -1,6 +1,7 @@
 import click
 import os
 from os.path import join, abspath
+import glob
 
 
 @click.command(name='shell', help='Start a shell to interact with the required bot.')
@@ -15,21 +16,22 @@ def command(language: str, debug: bool, response_timeout: int):
 
     Args:
         language (str): language code of the bot for rasa shell to be run
+        debug (bool): launch shell in debug mode
+        response_timeout (int): maximum time a response can take to process (sec.) (default: 3600)
     """
     start_shell(language, debug, response_timeout)
 
 
 def start_shell(language: str, debug: bool, response_timeout: int):
 
-    model_path = join(abspath('.'), 'languages', language,
-                      'models', f'model-{language}.tar.gz')
+    list_of_models = glob.glob(join(abspath("."), "languages", language, "models", "*.tar.gz"))
+    latest_file = max(list_of_models, key=os.path.getctime)
+
     endpoints_path = join(abspath('.'), 'endpoints.yml')
 
-    os.system(f'rasa shell --model {model_path} --response-timeout {response_timeout} {"--debug" if debug else ""} \
-              --endpoints {endpoints_path}')
+    os.system(f'rasa shell --model {latest_file} --response-timeout {response_timeout} \
+              {"--debug" if debug else ""} --endpoints {endpoints_path}')
 
 
 if __name__ == "__main__":
     command()
-
-# rasa shell --model $model --debug --endpoints $endpoints

--- a/robo_bot_cli/commands/train.py
+++ b/robo_bot_cli/commands/train.py
@@ -6,18 +6,19 @@ from datetime import datetime
 from robo_bot_cli.util.cli import print_info
 
 
-@click.command(name='train', help='Train Rasa models for the required bots.')
-@click.argument('languages', nargs=-1,)
-@click.option('--path', default='.', type=click.Path(), help="Directory of your bot to be trained.")
-@click.option('--dev-config', default='config.yml', type=str,
+@click.command(name="train", help="Train Rasa models for the required bots.")
+@click.argument("languages", nargs=-1,)
+@click.option("--path", default=".", type=click.Path(), help="Directory of your bot to be trained.")
+@click.option("--dev-config", default="config.yml", type=str,
               help="Name of the config file to be used. If this is not passed, default 'config.yml' is used.")
-@click.option('--nlu', '-n', 'nlu', is_flag=True,
+@click.option("--nlu", "-n", "nlu", is_flag=True,
               help="Train exclusively the RASA nlu model for the given languages")
-@click.option('--core', '-c', 'core', is_flag=True,
+@click.option("--core", "-c", "core", is_flag=True,
               help="Train exclusively the RASA core model for the given languages")
-@click.option('--augmentation', 'augmentation', default=50, help="How much data augmentation to use during training. \
+@click.option("--augmentation", "augmentation", default=50, help="How much data augmentation to use during training. \
               (default: 50)")
-def command(languages: tuple, path: str, dev_config: str, nlu: bool, core: bool, augmentation: int):
+@click.option("--force", "force", is_flag=True, default=False, help="Force a model training even if the data has not changed. (default: False)")
+def command(languages: tuple, path: str, dev_config: str, nlu: bool, core: bool, augmentation: int, force: bool):
     """
     Wrapper of rasa train for multi-language bots.
 
@@ -33,11 +34,11 @@ def command(languages: tuple, path: str, dev_config: str, nlu: bool, core: bool,
     languages_paths = get_all_languages(path=path, languages=languages)
 
     if nlu:
-        train_nlu(path, languages_paths, dev_config)
+        train_nlu(path, languages_paths, dev_config, force)
     elif core:
-        train_core(path, languages_paths, augmentation, dev_config)
+        train_core(path, languages_paths, augmentation, dev_config, force)
     else:
-        train(path, languages_paths, augmentation, dev_config)
+        train(path, languages_paths, augmentation, dev_config, force)
 
     # print_success("All training tasks completed")
 
@@ -52,39 +53,40 @@ def _inform_language() -> None:
 def get_all_languages(path: str, languages: tuple):
     if len(languages) == 0:
         _inform_language
-        languages_paths = [join(path, 'languages', folder) for folder in os.listdir(join(path, 'languages'))
-                           if os.path.isdir(os.path.join(path, 'languages', folder))]
+        languages_paths = [join(path, "languages", folder) for folder in os.listdir(join(path, "languages"))
+                           if os.path.isdir(os.path.join(path, "languages", folder))]
     else:
-        languages_paths = [join(path, 'languages', folder) for folder in os.listdir(join(path, 'languages'))
-                           if os.path.isdir(os.path.join(path, 'languages', folder)) and folder in languages]
+        languages_paths = [join(path, "languages", folder) for folder in os.listdir(join(path, "languages"))
+                           if os.path.isdir(os.path.join(path, "languages", folder)) and folder in languages]
     return languages_paths
 
 
-def train(path: str, languages_paths: list, augmentation: int, dev_config: str):
+def train(path: str, languages_paths: list, augmentation: int, dev_config: str, force: bool):
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    stories_path = join(path, 'languages', 'stories.md')
+    stories_path = join(path, "languages", "stories.md")
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
         os.system(f"rasa train --config {join(language_path, dev_config)} --domain {join(language_path,'domain.yml')} \
-        --data {join(language_path,'data')} {stories_path} --augmentation {augmentation} \
+        --data {join(language_path,'data')} {stories_path} --augmentation {augmentation} {'--force' if force else ''} \
         --out {join(language_path, 'models')} --fixed-model-name model-{lang}-{timestamp}")
 
 
-def train_nlu(path: str, languages_paths: list, dev_config: str):
+def train_nlu(path: str, languages_paths: list, dev_config: str, force: bool):
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
         os.system(f"rasa train nlu --nlu {join(language_path,'data')} --config {join(language_path, dev_config)} \
+                  {'--force' if force else ''} \
                   --out {join(language_path, 'models')} --fixed-model-name nlu-model-{lang}-{timestamp}")
 
 
-def train_core(path: str, languages_paths: list, augmentation: int, dev_config: str):
+def train_core(path: str, languages_paths: list, augmentation: int, dev_config: str, force: bool):
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     stories_path = join(path, 'languages', 'stories.md')
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
         os.system(f"rasa train core --domain {join(language_path,'domain.yml')} --stories {stories_path} \
-                  --augmentation {augmentation} --config {join(language_path, dev_config)} \
+                  --augmentation {augmentation} --config {join(language_path, dev_config)} {'--force' if force else ''} \
                   --out {join(language_path, 'models')} --fixed-model-name core-model-{lang}-{timestamp}")
 
 

--- a/robo_bot_cli/commands/train.py
+++ b/robo_bot_cli/commands/train.py
@@ -61,7 +61,7 @@ def get_all_languages(path: str, languages: tuple):
 
 
 def train(path: str, languages_paths: list, augmentation: int, dev_config: str):
-    timestamp = datetime.now().strftime("%d%m%Y-%H%M%S")
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     stories_path = join(path, 'languages', 'stories.md')
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
@@ -71,7 +71,7 @@ def train(path: str, languages_paths: list, augmentation: int, dev_config: str):
 
 
 def train_nlu(path: str, languages_paths: list, dev_config: str):
-    timestamp = datetime.now().strftime("%d%m%Y-%H%M%S")
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
         os.system(f"rasa train nlu --nlu {join(language_path,'data')} --config {join(language_path, dev_config)} \
@@ -79,7 +79,7 @@ def train_nlu(path: str, languages_paths: list, dev_config: str):
 
 
 def train_core(path: str, languages_paths: list, augmentation: int, dev_config: str):
-    timestamp = datetime.now().strftime("%d%m%Y-%H%M%S")
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     stories_path = join(path, 'languages', 'stories.md')
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))

--- a/robo_bot_cli/commands/train.py
+++ b/robo_bot_cli/commands/train.py
@@ -17,7 +17,8 @@ from robo_bot_cli.util.cli import print_info
               help="Train exclusively the RASA core model for the given languages")
 @click.option("--augmentation", "augmentation", default=50, help="How much data augmentation to use during training. \
               (default: 50)")
-@click.option("--force", "force", is_flag=True, default=False, help="Force a model training even if the data has not changed. (default: False)")
+@click.option("--force", "-f", "force", is_flag=True, default=False,
+              help="Force a model training even if the data has not changed. (default: False)")
 def command(languages: tuple, path: str, dev_config: str, nlu: bool, core: bool, augmentation: int, force: bool):
     """
     Wrapper of rasa train for multi-language bots.
@@ -34,7 +35,7 @@ def command(languages: tuple, path: str, dev_config: str, nlu: bool, core: bool,
     languages_paths = get_all_languages(path=path, languages=languages)
 
     if nlu:
-        train_nlu(path, languages_paths, dev_config, force)
+        train_nlu(path, languages_paths, dev_config)
     elif core:
         train_core(path, languages_paths, augmentation, dev_config, force)
     else:
@@ -66,8 +67,8 @@ def train(path: str, languages_paths: list, augmentation: int, dev_config: str, 
     stories_path = join(path, "languages", "stories.md")
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
-        os.system(f"rasa train --config {join(language_path, dev_config)} --domain {join(language_path,'domain.yml')} \
-        --data {join(language_path,'data')} {stories_path} --augmentation {augmentation} {'--force' if force else ''} \
+        os.system(f"rasa train --config {join(language_path, dev_config)} --domain {join(language_path, 'domain.yml')} \
+        --data {join(language_path, 'data')} {stories_path} --augmentation {augmentation} {'--force' if force else ''} \
         --out {join(language_path, 'models')} --fixed-model-name model-{lang}-{timestamp}")
 
 
@@ -75,8 +76,7 @@ def train_nlu(path: str, languages_paths: list, dev_config: str, force: bool):
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
-        os.system(f"rasa train nlu --nlu {join(language_path,'data')} --config {join(language_path, dev_config)} \
-                  {'--force' if force else ''} \
+        os.system(f"rasa train nlu --nlu {join(language_path, 'data')} --config {join(language_path, dev_config)} \
                   --out {join(language_path, 'models')} --fixed-model-name nlu-model-{lang}-{timestamp}")
 
 
@@ -85,7 +85,7 @@ def train_core(path: str, languages_paths: list, augmentation: int, dev_config: 
     stories_path = join(path, 'languages', 'stories.md')
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
-        os.system(f"rasa train core --domain {join(language_path,'domain.yml')} --stories {stories_path} \
+        os.system(f"rasa train core --domain {join(language_path, 'domain.yml')} --stories {stories_path} \
                   --augmentation {augmentation} --config {join(language_path, dev_config)} {'--force' if force else ''} \
                   --out {join(language_path, 'models')} --fixed-model-name core-model-{lang}-{timestamp}")
 

--- a/robo_bot_cli/commands/train.py
+++ b/robo_bot_cli/commands/train.py
@@ -1,6 +1,7 @@
 import click
 import os
 from os.path import join
+from datetime import datetime
 
 from robo_bot_cli.util.cli import print_info
 
@@ -33,7 +34,7 @@ def command(languages: tuple, path: str, dev_config: str, nlu: bool, core: bool,
 
     if nlu:
         train_nlu(path, languages_paths, dev_config)
-    if core:
+    elif core:
         train_core(path, languages_paths, augmentation, dev_config)
     else:
         train(path, languages_paths, augmentation, dev_config)
@@ -60,28 +61,31 @@ def get_all_languages(path: str, languages: tuple):
 
 
 def train(path: str, languages_paths: list, augmentation: int, dev_config: str):
+    timestamp = datetime.now().strftime("%d%m%Y-%H%M%S")
     stories_path = join(path, 'languages', 'stories.md')
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
         os.system(f"rasa train --config {join(language_path, dev_config)} --domain {join(language_path,'domain.yml')} \
         --data {join(language_path,'data')} {stories_path} --augmentation {augmentation} \
-        --out {join(language_path, 'models')} --fixed-model-name model-{lang}")
+        --out {join(language_path, 'models')} --fixed-model-name model-{lang}-{timestamp}")
 
 
 def train_nlu(path: str, languages_paths: list, dev_config: str):
+    timestamp = datetime.now().strftime("%d%m%Y-%H%M%S")
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
         os.system(f"rasa train nlu --nlu {join(language_path,'data')} --config {join(language_path, dev_config)} \
-                  --out {join(language_path, 'models')} --fixed-model-name nlu-model-{lang}")
+                  --out {join(language_path, 'models')} --fixed-model-name nlu-model-{lang}-{timestamp}")
 
 
 def train_core(path: str, languages_paths: list, augmentation: int, dev_config: str):
+    timestamp = datetime.now().strftime("%d%m%Y-%H%M%S")
     stories_path = join(path, 'languages', 'stories.md')
     for language_path in languages_paths:
         lang = os.path.basename(language_path)  # os.path.split(os.path.dirname(language_path))
         os.system(f"rasa train core --domain {join(language_path,'domain.yml')} --stories {stories_path} \
                   --augmentation {augmentation} --config {join(language_path, dev_config)} \
-                  --out {join(language_path, 'models')} --fixed-model-name core-model-{lang}")
+                  --out {join(language_path, 'models')} --fixed-model-name core-model-{lang}-{timestamp}")
 
 
 if __name__ == "__main__":

--- a/robo_bot_cli/util/robo.py
+++ b/robo_bot_cli/util/robo.py
@@ -272,12 +272,11 @@ def copy_dir(source_path: str, dest_path: str):
 
 
 def copy_file(source_path: str, dest_path: str):
-    copyfile(source_path, dest_path)
-    # try:
-    #     # print("Trying to copy file from {} to {}".format(source_path, dest_path))
-    #     copyfile(source_path, dest_path)
-    # except Exception:
-    #     print("Couldn't copy file from {} to {}".format(source_path, dest_path))
+    try:
+        # print("Trying to copy file from {} to {}".format(source_path, dest_path))
+        copyfile(source_path, dest_path)
+    except Exception:
+        print("Couldn't copy file from {} to {}".format(source_path, dest_path))
 
 
 def create_package(bot_language_dir: str, bot_root_dir: str, model: str) -> str:

--- a/robo_bot_cli/util/robo.py
+++ b/robo_bot_cli/util/robo.py
@@ -245,7 +245,7 @@ def copy_directories(bot_language_dir: str, bot_root_dir: str, model: str):
     copy_file(join(bot_root_dir, 'languages', 'stories.md'), join(TEMP_DIR, 'data', 'stories.md'))
     if model:
         model_name = model.split("/")[-1]
-        copy_file(model, join(TEMP_DIR, "models", model_name))
+        copy_file(join(bot_language_dir, "models", model_name), join(TEMP_DIR, "models", model_name))
     else:
         list_of_models = glob.glob(join(bot_language_dir, "models", "*.tar.gz"))
         latest_file = max(list_of_models, key=os.path.getctime)
@@ -271,11 +271,12 @@ def copy_dir(source_path: str, dest_path: str):
 
 
 def copy_file(source_path: str, dest_path: str):
-    try:
-        # print("Trying to copy file from {} to {}".format(source_path, dest_path))
-        copyfile(source_path, dest_path)
-    except Exception:
-        print("Couldn't copy file from {} to {}".format(source_path, dest_path))
+    copyfile(source_path, dest_path)
+    # try:
+    #     # print("Trying to copy file from {} to {}".format(source_path, dest_path))
+    #     copyfile(source_path, dest_path)
+    # except Exception:
+    #     print("Couldn't copy file from {} to {}".format(source_path, dest_path))
 
 
 def create_package(bot_language_dir: str, bot_root_dir: str, model: str) -> str:

--- a/robo_bot_cli/util/robo.py
+++ b/robo_bot_cli/util/robo.py
@@ -243,6 +243,7 @@ def copy_directories(bot_language_dir: str, bot_root_dir: str, model: str):
     copy_dir(join(bot_root_dir, 'actions'), join(TEMP_DIR, 'actions'))
     copy_dir(join(bot_language_dir, 'data'), join(TEMP_DIR, 'data'))
     copy_file(join(bot_root_dir, 'languages', 'stories.md'), join(TEMP_DIR, 'data', 'stories.md'))
+    os.makedirs(join(TEMP_DIR, "models"), exist_ok=True)
     if model:
         model_name = model.split("/")[-1]
         copy_file(join(bot_language_dir, "models", model_name), join(TEMP_DIR, "models", model_name))


### PR DESCRIPTION
- Add timestamp to model name.
- Fix issue when launching shell or interactive mode - now these commands pick up the latest model.
- Add option to pass model path in deploy and package commands. If no model path is passed, the most recent model is picked up for deployment/packaging.
- Add force option to train command.
